### PR TITLE
Change papercall link

### DIFF
--- a/themes/200ok/layout/index.ejs
+++ b/themes/200ok/layout/index.ejs
@@ -1,6 +1,6 @@
 <div class="text-center">
   <div>
-    <a href="https://www.papercall.io/cfps/2907/submissions/new"
+    <a href="https://www.papercall.io/200ok"
        class="inline-block bg-green-500 hover:bg-green-700 text-white font-bold py-4 px-8 rounded my-12 text-2xl">
       Submit a Talk
     </a>


### PR DESCRIPTION
Thanks so much for working on this, @travismiller !

Can we change the paper call link to the landing page for the conference (as shown) so that people can see what the conference is about before having to log in? 

The current link just sends me to a log in page, and I don't get to see anything about the conference until I log in. Since our homepage is also pretty sparse, I'm thinking it would be a good idea to give some conference info first. Let me know what you think.