### PR TITLE
Add GitHub Actions for auto deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-deploy:
+    name: "Master Build & Deploy"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Node.js dependencies
+        run: npm install
+      - name: Hexo Generate
+        run: npm run build
+      - name: Hexo Deploy
+        env:
+          PRIVATE_KEY: ${{ secrets.PRIVATE_DEPLOY_KEY }}
+        run: |
+          eval $(ssh-agent -s)
+          ssh-add <(echo "$PRIVATE_KEY")
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git config --global user.name "${GITHUB_ACTOR}"
+          npm run deploy

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,22 @@
+name: Pull Request
+
+on:
+  push:
+    branches-ignore:
+      - master
+      - gh-pages
+
+jobs:
+  build:
+    name: "Pull Request Build"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '10.x'
+      - name: Install Node.js dependencies
+        run: npm install
+      - name: Hexo Generate
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# [200ok.us](http://200ok.us/) source files
+# [200ok.us](https://200ok.us/) source files
 
-This is a static website deployed on gh-pages, built with [hexo](https://hexo.io/).
+This is a static website deployed on [GitHub Pages](https://pages.github.com/), built with [Hexo](https://hexo.io/).
 
 ### Installing
 
-```
-git clone git@github.com:techlahoma/200ok-site.git
-cd 200ok-site
-npm install
+```console
+$ git clone git@github.com:techlahoma/200ok-site.git
+$ cd 200ok-site
+$ npm install
 ```
 
 ### File Structure
@@ -16,17 +16,12 @@ All the copy documents are in `/source`, the theme is `/themes/200ok`, and the o
 
 ### Working locally on the site
 
-```
-./node_modules/.bin/hexo serve
+```console
+$ npm run start
 ```
 
 Then go to http://localhost:4000
 
 ### Deploy Changes
 
-```
-./node_modules/.bin/hexo generate
-./node_modules/.bin/hexo deploy
-```
-
-This will generate the static files and deploy to github pages.
+The `master` branch is automatically deployed to [200ok.us](https://200ok.us/) via [GitHub Actions](https://github.com/features/actions). See [.github/workflows/deploy.yml](.github/workflows/deploy.yml).

--- a/_config.yml
+++ b/_config.yml
@@ -6,13 +6,13 @@
 title: 200ok
 subtitle:
 description:
-author: John Doe
+author: Techlahoma
 language:
 timezone:
 
 # URL
 ## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
-url: http://200ok.us
+url: https://200ok.us
 root: /
 permalink: :year/:month/:day/:title/
 permalink_defaults:


### PR DESCRIPTION
This PR adds an automated deployment with GitHub Actions.

## Configuration Steps

- [x] Deployment Key (public part of RSA key) - `SSH techlahoma/200ok-site`
- [x] Secret Environment Variable (private part of RSA key) - `PRIVATE_DEPLOY_KEY`
- https://github.com/techlahoma/200ok-site/settings/branches
  - `master`
    - [x] Require status checks to pass before merging
      - [x] Require branches to be up to date before merging
        - [x] `Pull Request Build`
    - [x] Include administrators
  - `gh-pages`
    - [x] Allow force pushes

Deployment key and secret are used for write access back to the repository for force pushing the `gh-pages` branch during the deployment.
