### PR TITLE
Add GitWit as an H2 sponsor

### DIFF
--- a/themes/200ok/layout/index.ejs
+++ b/themes/200ok/layout/index.ejs
@@ -6,13 +6,63 @@
     </a>
   </div>
 
-  <div class="full-width reverse ; my-12 p-8 pb-12">
-    <div class="max-w-2xl mx-auto">
+  <div class="full-width reverse ; my-12 py-4">
+    <h3>Sponsors</h3>
 
-      <p>200OK is going virtual this year! Join us May 15th for a great speaker line up.</p>
+    <a href="/sponsorship-prospectus/">
+      Sponsorship Prospectus
+    </a>
 
+    <div class="my-12 hidden">
+      <h4>
+        <a href="sponsorship-prospectus#lt-title-gt-Sponsor-3-000" class="block">
+          <code class="text-white">&lt;title&gt;</code>
+        </a>
+      </h4>
     </div>
 
+    <div class="my-12 hidden">
+      <h4>
+        <a href="sponsorship-prospectus#lt-br-class-quot-Lunch-quot-gt-Sponsor-2-000" class="block">
+          <code class="text-white">&lt;br class="Lunch"&gt;</code>
+        </a>
+      </h4>
+    </div>
+
+    <div class="my-12 hidden">
+      <h4>
+        <a href="sponsorship-prospectus#lt-h1-gt-Sponsor-2-000" class="block">
+          <code class="text-white">&lt;h1&gt;</code>
+        </a>
+      </h4>
+    </div>
+
+    <div class="my-12 hidden">
+      <h4>
+        <a href="sponsorship-prospectus#lt-br-class-quot-Breakfast-quot-gt-Sponsor-1-000" class="block">
+          <code class="text-white">&lt;br class="Breakfast"&gt;</code>
+        </a>
+      </h4>
+    </div>
+
+    <div class="my-12">
+      <h4>
+        <a href="sponsorship-prospectus#lt-h2-gt-Sponsor-1-000" class="block">
+          <code class="text-white">&lt;h2&gt;</code>
+        </a>
+      </h4>
+      <a class="bg-white inline-block max-w-xs" target="_blank" href="https://www.gitwit.com/" title="GitWit">
+        <img src="/assets/media/sponsors/gitwit.png" alt="GitWit">
+      </a>
+    </div>
+
+    <div class="my-12 hidden">
+      <h4>
+        <a href="sponsorship-prospectus#lt-a-gt-“Local”-Sponsor-Vary-Referer" class="block">
+          <code class="text-white">&lt;a&gt;</code>
+        </a>
+      </h4>
+    </div>
   </div>
 
   <div>


### PR DESCRIPTION
Add GitWit as an H2 sponsor.

Also removed mostly redundant "virtual" text.

Review link: https://deploy-preview-140--200ok.netlify.app/

| Desktop | Mobile |
| --- | --- |
| ![Screen Shot 2020-05-01 at 08 34 19](https://user-images.githubusercontent.com/494017/80809084-9763cc80-8b86-11ea-9358-a20de1f3eea0.png) | ![Screen Shot 2020-05-01 at 08 34 30](https://user-images.githubusercontent.com/494017/80809090-99c62680-8b86-11ea-9dca-f915c690cba0.png) |
