### PR TITLE
Prepare site for hosting on Netlify and requesting open source plan

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node.js dependencies
         run: npm install
       - name: Hexo Generate
-        run: npm run build
+        run: npm run build && rm public/robots.txt
       - name: Hexo Deploy
         env:
           PRIVATE_KEY: ${{ secrets.PRIVATE_DEPLOY_KEY }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,7 @@ name: Pull Request
 on:
   push:
     branches-ignore:
+      - main
       - master
       - gh-pages
 
@@ -15,7 +16,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '10.x'
+          node-version: "10.x"
       - name: Install Node.js dependencies
         run: npm install
       - name: Hexo Generate

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# What to Expect From Techlahoma Regarding Our Code of Conduct and Anti-Harassment Policy
+
+All attendees of in-person events and online gatherings are expected to follow our Code of Conduct, which includes our anti-harassment policy. The COC holds attendees to regard themselves in a professional and collaborative manner while engaging in any Techlahoma activity. If you need help with a COC violation or require any immediate assistance, consider following any of these steps below:
+
+1. Contact police, if needed
+1. Contact your event organizers right away
+1. [Fill out an incident report form to have your issue reviewed immediately.](https://www.techlahoma.org/incident/)
+1. Join and post in the public Techlahoma Slack channel #ask-a-mod to contact all admins
+1. Contact all Slack admins in any channel by typing @admins
+1. Contact all Conduct Committee representatives my typing @mods
+1. Send an email at info@techlahoma.org to the Techlahoma organizer team
+
+Techlahoma leadership is here to support safe, fun, educational, professional and friendly events. If you or someone else needs help, don’t hesitate to contact us. We can help you file a police report if that situation is needed, escort you to your vehicle, stay with you for the duration of an event, remove threatening/coc-violating individuals, refund your ticket, and more to help you feel recognized and accommodated. **It’s our responsibility to take your safety concerns seriously.**
+
+---
+
+## Code of Conduct
+
+We expect all participants will be considerate, respectful, and collaborative at all community events.
+
+The CoC applies to all participants. Participants include attendees, speakers, organizers, volunteers, sponsors, vendors and staff.
+
+The CoC applies at all official and unofficial events. Unofficial events include any location where attendees may be congregating.
+
+## Anti-Harassment Policy
+
+Our Anti-Harassment Policy prohibits the following:
+
+- Offensive comments related to gender, gender identity and expression, age, sexual orientation, race, religion, disability, body size, physical appearance, immigrant status or country of origin
+- Sexual or otherwise inappropriate images and hateful speech/jokes (including in presentations)
+- Deliberate intimidation, stalking, or following
+- Harassing photography or recording
+- Inappropriate or otherwise unwelcome physical contact or sexual attention (including unwanted hugs, touches or touching pregnant bellies)
+- Sustained disruption of talks or events
+- Harassing, abusive, discriminatory or derogatory conduct
+
+## Expectations for our Community
+
+### Organizers
+
+Event organizers will:
+
+- Uphold the CoC and be excellent examples of personal and professional conduct
+- Attempt to prevent potential CoC violations and keep vigilant in watching for persons in need of help
+- Contact local law enforcement or venue security
+- Provide escorts to anyone requesting safety and security
+- Assist those experiencing harassment to feel safe for the duration of the event
+
+The event organizers will take appropriate action against unacceptable behavior. Organizers may expel participants from the event without warning or refund.
+
+### Everyone
+
+At all community and social events we expect everyone will:
+
+- Be considerate, respectful, and collaborative
+- Refrain from demeaning, discriminatory, or harassing behavior and speech
+- Act and engage in an authentic, thoughtful, and empathetic way to help to foster our community
+- Be mindful of your surroundings and of your fellow participants
+- Alert meeting organizers and volunteers if you notice CoC violations, someone in distress or a dangerous situation
+
+### Sponsors, Staff
+
+Sponsors (otherwise known as vendors, booth staff) and other staff are subject to the anti-harassment policy. Sponsors and staff agree to the following:
+
+- No Inappropriate and offensive material
+- No sexualised images or activities
+- No sexualised clothing/uniforms/costumes
+
+About our Community CoC
+
+Current Techlahoma Event Code of Conduct based on our friends in [OKCrb], [Burlington Ruby], and [JS Conf/Ada Iniative].
+
+This work is licensed under a Creative Commons Attribution 3.0 Unported License
+
+[OKCrb]: http://www.okcruby.org/about/
+[Burlington Ruby]: http://burlingtonrubyconference.com/conduct.html
+[JS Conf/Ada Iniative]: http://jsconf.com/codeofconduct.html

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 The Techlahoma Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # [200ok.us](https://200ok.us/) source files
 
-This is a static website deployed on [GitHub Pages](https://pages.github.com/), built with [Hexo](https://hexo.io/).
+[![Netlify Status](https://api.netlify.com/api/v1/badges/10be3658-c444-423a-a7a2-9d326f1dd1fb/deploy-status)](https://app.netlify.com/sites/200ok/deploys)
+
+This is a static website deployed on [Netlify](https://www.netlify.com/), built with [Hexo](https://hexo.io/).
 
 ### Installing
 
@@ -24,4 +26,12 @@ Then go to http://localhost:4000
 
 ### Deploy Changes
 
-The `main` branch is automatically deployed to [200ok.us](https://200ok.us/) via [GitHub Actions](https://github.com/features/actions). See [.github/workflows/deploy.yml](.github/workflows/deploy.yml).
+The `main` branch is automatically deployed to [200ok.us](https://200ok.us/) with [Netlify site deploys](https://docs.netlify.com/site-deploys/overview/). See [netlify.toml](netlify.toml).
+
+## Code of Conduct
+
+This repository is governed by [Techlahoma’s Code of Conduct](https://www.techlahoma.org/code-of-conduct).
+
+## License
+
+This software is licensed under the MIT License. For more information, read this repository’s [LICENSE](LICENSE).

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  base = "."
+  publish = "public/"
+  command = "make build"
+
+[context.production]
+  command = "make build && rm public/robots.txt"

--- a/themes/200ok/layout/_partial/footer.ejs
+++ b/themes/200ok/layout/_partial/footer.ejs
@@ -10,6 +10,13 @@
   </ul>
 
   <p>Copyright 2021 — <a href="https://www.techlahoma.org/" style="color:#999;">Techlahoma</a></p>
+  <% if (process.env.NETLIFY) { %>
+  <p>
+    <a href="https://www.netlify.com">
+      <img src="https://www.netlify.com/img/global/badges/netlify-dark.svg" alt="Deploys by Netlify" class="; mx-auto w-20" />
+    </a>
+  </p>
+  <% } %>
 </div>
 
 <!-- Analytics -->

--- a/themes/200ok/source/robots.txt
+++ b/themes/200ok/source/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This PR prepares the repository for hosting on Netlify.

Also:
- Add a robots.txt that prevents indexing on non-production sites. This file is removed for production deploys.

## Review

- https://deploy-preview-150--200ok.netlify.app/
- https://deploy-preview-150--200ok.netlify.app/robots.txt

Test with and without the `NETLIFY` environment variable to conditionally display the "deploys by Netlify" badge.

```console
$ NETLIFY=true npm run start
```

```console
$ npm run start
```

## Resources

- https://www.netlify.com/legal/open-source-policy/
- https://opensource-form.netlify.com/
- https://docs.netlify.com/configure-builds/get-started/
- https://www.robotstxt.org/robotstxt.html

## Checklist

- [x] Add a license (MIT)
- [x] Add a Code of Conduct (Techlahoma’s)
- [x] Link to Netlify