### PR TITLE
Netlify: Redirect default subdomain to primary domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL = /bin/bash
 
+ROBOTS = public/robots.txt
+
 default: build
 
 dev: node_modules
@@ -8,8 +10,11 @@ dev: node_modules
 build: node_modules
 	npm run build
 
-deploy: node_modules
-	npm run deploy
+# https://docs.netlify.com/configure-builds/environment-variables/#read-only-variables
+# CONTEXT: production | deploy-preview | branch-deploy
+deploy-netlify: build
+	[ ! -f "$(ROBOTS).$(CONTEXT)" ] || cp "$(ROBOTS).$(CONTEXT)" $(ROBOTS)
+	rm -f $(ROBOTS).*
 
 node_modules: package.json package-lock.json
 	npm install

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,11 @@
 [build]
   base = "."
   publish = "public/"
-  command = "make build"
+  command = "make deploy-netlify"
 
-[context.production]
-  command = "make build && rm public/robots.txt"
+# Redirect the default subdomain to the primary domain
+[[redirects]]
+  from = "https://200ok.netlify.app/*"
+  to = "https://200ok.us/:splat"
+  status = 301
+  force = true

--- a/themes/200ok/source/robots.txt.production
+++ b/themes/200ok/source/robots.txt.production
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow:


### PR DESCRIPTION
- Redirect 200ok.netlify.app to 200ok.us
- Explicit Netlify deploy make target
- Add a production robots.txt