### PR TITLE
Add attendee map page

### DIFF
--- a/assets/map/200ok-floor-1.svg
+++ b/assets/map/200ok-floor-1.svg
@@ -1,0 +1,140 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 810" role="img" aria-labelledby="floor-1-title floor-1-desc">
+  <title id="floor-1-title">200ok Gitwit attendee map production draft, floor 1</title>
+  <desc id="floor-1-desc">Approximate manual redraw of floor 1 from the Gitwit Office Layout PDF. Restrooms are in the north attendee area, The Kitchen is north-center, Check-in is at the Front Desk in the southwest-middle area, The CAFE is on the south side, The FORUM is south-center, The CUBE is on the southeast side as Speaker's Green Room except during Breakout Sessions, and Mother's Room is on the east side. Unavailable areas are neutralized. Not for emergency egress or exact measurement.</desc>
+  <defs>
+    <pattern id="neutral-hatch" width="10" height="10" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="10" stroke="#c7b7ad" stroke-width="2" />
+    </pattern>
+    <style>
+      .page { fill: #f4efe8; }
+      .building { fill: #fffaf4; stroke: #4a1d0f; stroke-width: 3; rx: 14px; ry: 14px; }
+      .zone { stroke: #4a1d0f; stroke-width: 2; rx: 12px; ry: 12px; }
+      .public { fill: #4a1d0f; }
+      .conditional { fill: #4a1d0f; stroke: #da6343; stroke-width: 4; }
+      .amenity { fill: #803c28; }
+      .restroom { fill: #da6343; }
+      .neutral { fill: #ded8d1; }
+      .neutral-hatched { fill: url(#neutral-hatch); rx: 12px; ry: 12px; }
+      .circulation { fill: #fffaf4; stroke: #803c28; stroke-width: 2; stroke-dasharray: 8 6; stroke-opacity: 0.58; }
+      .label { font-family: Arial, Helvetica, sans-serif; font-size: 18px; font-weight: 700; text-anchor: middle; dominant-baseline: middle; fill: #fffaf4; }
+      .label-dark { fill: #4a1d0f; }
+      .label-restroom { fill: #38150b; }
+      .label-small { font-size: 13px; }
+      .label-xs { font-size: 11px; }
+      .legend-text { font-family: Arial, Helvetica, sans-serif; font-size: 14px; fill: #4a1d0f; dominant-baseline: middle; }
+      .note { font-family: Arial, Helvetica, sans-serif; font-size: 13px; fill: #803c28; }
+      .title { font-family: Arial, Helvetica, sans-serif; font-size: 32px; font-weight: 800; fill: #4a1d0f; }
+      .subtitle { font-family: Arial, Helvetica, sans-serif; font-size: 16px; fill: #803c28; }
+    </style>
+  </defs>
+
+  <!-- Production draft geometry: intentionally simplified from the rendered PDF, not auto-traced. -->
+  <rect class="page" width="1440" height="810" />
+  <text x="56" y="52" class="title">Floor 1</text>
+  <text x="56" y="80" class="subtitle">Production draft. Verify room geometry and schedule names before sharing.</text>
+  <text x="56" y="128" class="note">Unavailable areas are intentionally neutralized. Not for emergency egress.</text>
+
+  <g id="floor-1-legend">
+    <rect x="1100" y="28" width="22" height="22" class="zone public" />
+    <text x="1132" y="39" class="legend-text">Public/session area</text>
+    <rect x="1100" y="54" width="22" height="22" class="zone amenity" />
+    <text x="1132" y="65" class="legend-text">Amenity/gathering</text>
+    <rect x="1100" y="80" width="22" height="22" class="zone restroom" />
+    <text x="1132" y="91" class="legend-text">Restrooms</text>
+    <rect x="1100" y="106" width="22" height="22" class="zone conditional" />
+    <text x="1132" y="117" class="legend-text">Schedule-dependent room</text>
+    <rect x="1100" y="132" width="22" height="22" class="zone neutral" />
+    <text x="1132" y="143" class="legend-text">Unavailable area</text>
+  </g>
+
+  <g id="floor-1-building-outline">
+    <rect class="building" x="28" y="156" width="1392" height="644" />
+  </g>
+
+  <g id="floor-1-unavailable-space">
+    <rect id="floor-1-unavailable-west" x="34" y="356" width="142" height="114" class="zone neutral" />
+    <rect id="floor-1-unavailable-west-middle" x="34" y="504" width="126" height="122" class="zone neutral" />
+    <rect id="floor-1-unavailable-west-south" x="34" y="642" width="94" height="150" class="zone neutral" />
+    <rect id="floor-1-unavailable-southwest" x="130" y="704" width="230" height="78" class="zone neutral" />
+    <rect id="floor-1-unavailable-center-east" x="612" y="492" width="105" height="178" class="zone neutral" />
+    <rect id="floor-1-unavailable-north-row" x="882" y="366" width="373" height="78" class="zone neutral" />
+    <rect id="floor-1-unavailable-east-row" x="1180" y="452" width="75" height="197" class="zone neutral" />
+    <rect id="floor-1-unavailable-far-east" x="1313" y="358" width="103" height="421" class="zone neutral" />
+  </g>
+
+  <g id="floor-1-public-circulation">
+    <path class="circulation" d="M180 485 H735 V690 H1005 V448 H1288 V780 H370 V620 H180 Z" />
+    <text x="1040" y="472" class="note" text-anchor="middle">Simplified circulation. No route, ADA, or egress claims.</text>
+  </g>
+
+  <g id="neutral-floor-1-staff-area-west" class="room neutral-block" data-label="Staff area" aria-hidden="true">
+    <rect x="198" y="374" width="78" height="98" class="zone neutral" />
+  </g>
+
+  <g id="floor-1-restrooms" class="room amenity-block" data-label="Restrooms">
+    <title>Restrooms</title>
+    <rect x="300" y="364" width="174" height="116" class="zone restroom" />
+    <text x="387" y="422" class="label label-restroom label-small">Restrooms</text>
+  </g>
+
+  <g id="floor-1-kitchen" class="room amenity-block" data-label="The Kitchen">
+    <title>The Kitchen</title>
+    <rect x="486" y="364" width="226" height="116" class="zone amenity" />
+    <text x="599" y="413" class="label label-small">The</text>
+    <text x="599" y="435" class="label label-small">Kitchen</text>
+  </g>
+
+  <g id="neutral-floor-1-east-room" class="room neutral-block" aria-hidden="true">
+    <rect x="730" y="354" width="148" height="86" class="zone neutral" />
+  </g>
+
+  <g id="floor-1-forum" class="room public-room" data-label="The FORUM">
+    <title>The FORUM</title>
+    <rect x="746" y="532" width="208" height="164" class="zone public" />
+    <text x="850" y="606" class="label">The</text>
+    <text x="850" y="628" class="label">FORUM</text>
+  </g>
+
+  <g id="floor-1-cube" class="room conditional-room" data-label="The CUBE / Speaker Green Room / Breakout Sessions">
+    <title>The CUBE: Speaker's Green Room except during Breakout Sessions</title>
+    <rect x="1008" y="504" width="170" height="146" class="zone conditional" />
+    <text x="1093" y="546" class="label label-small">The CUBE</text>
+    <text x="1093" y="572" class="label label-small">Speaker</text>
+    <text x="1093" y="592" class="label label-small">Green Room</text>
+    <text x="1093" y="616" class="label label-xs">Breakouts when scheduled</text>
+  </g>
+
+  <g id="floor-1-cafe" class="room public-room" data-label="The CAFE">
+    <title>The CAFE</title>
+    <rect x="488" y="696" width="228" height="92" class="zone amenity" />
+    <text x="602" y="735" class="label">The</text>
+    <text x="602" y="758" class="label">CAFE</text>
+  </g>
+
+  <g id="floor-1-front-desk" class="room amenity-block" data-label="Front Desk">
+    <title>Check-in / Front Desk</title>
+    <rect x="374" y="620" width="130" height="56" class="zone amenity" />
+    <text x="439" y="641" class="label label-small">Check-in</text>
+    <text x="439" y="659" class="label label-xs">Front Desk</text>
+  </g>
+
+  <g id="floor-1-bathroom-3" class="room amenity-block" data-label="Restroom">
+    <title>Restroom</title>
+    <rect x="1124" y="220" width="62" height="76" class="zone restroom" />
+    <text x="1155" y="260" class="label label-restroom label-xs">Restroom</text>
+  </g>
+
+  <g id="floor-1-bathroom-4" class="room amenity-block" data-label="Restroom">
+    <title>Restroom</title>
+    <rect x="1194" y="220" width="62" height="76" class="zone restroom" />
+    <text x="1225" y="260" class="label label-restroom label-xs">Restroom</text>
+  </g>
+
+  <g id="floor-1-mothers-room" class="room amenity-block" data-label="Mother's Room">
+    <title>Mother's Room</title>
+    <rect x="1334" y="302" width="74" height="52" class="zone amenity" />
+    <text x="1371" y="321" class="label label-xs">Mother's</text>
+    <text x="1371" y="336" class="label label-xs">Room</text>
+  </g>
+
+</svg>

--- a/assets/map/200ok-floor-2.svg
+++ b/assets/map/200ok-floor-2.svg
@@ -1,0 +1,127 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 810" role="img" aria-labelledby="floor-2-title floor-2-desc">
+  <title id="floor-2-title">200ok Gitwit attendee map production draft, floor 2</title>
+  <desc id="floor-2-desc">Approximate manual redraw of floor 2 from the Gitwit Office Layout PDF. Restrooms are near west-center and northeast, The CURVE is on the southwest side, Extra Seating is on the southeast side, and Hallway is near center. Public attendee rooms and gathering areas are shown, while unavailable areas are neutralized. Not for emergency egress or exact measurement.</desc>
+  <defs>
+    <pattern id="neutral-hatch" width="10" height="10" patternUnits="userSpaceOnUse" patternTransform="rotate(45)">
+      <line x1="0" y1="0" x2="0" y2="10" stroke="#c7b7ad" stroke-width="2" />
+    </pattern>
+    <style>
+      .page { fill: #f4efe8; }
+      .building { fill: #fffaf4; stroke: #4a1d0f; stroke-width: 3; rx: 14px; ry: 14px; }
+      .zone { stroke: #4a1d0f; stroke-width: 2; rx: 12px; ry: 12px; }
+      .public { fill: #4a1d0f; }
+      .amenity { fill: #803c28; }
+      .restroom { fill: #da6343; }
+      .neutral { fill: #ded8d1; }
+      .neutral-hatched { fill: url(#neutral-hatch); rx: 12px; ry: 12px; }
+      .circulation { fill: #fffaf4; stroke: #803c28; stroke-width: 2; stroke-dasharray: 8 6; stroke-opacity: 0.58; }
+      .label { font-family: Arial, Helvetica, sans-serif; font-size: 18px; font-weight: 700; text-anchor: middle; dominant-baseline: middle; fill: #fffaf4; }
+      .label-dark { fill: #4a1d0f; }
+      .label-restroom { fill: #38150b; }
+      .label-small { font-size: 13px; }
+      .label-xs { font-size: 11px; }
+      .legend-text { font-family: Arial, Helvetica, sans-serif; font-size: 14px; fill: #4a1d0f; dominant-baseline: middle; }
+      .note { font-family: Arial, Helvetica, sans-serif; font-size: 13px; fill: #803c28; }
+      .title { font-family: Arial, Helvetica, sans-serif; font-size: 32px; font-weight: 800; fill: #4a1d0f; }
+      .subtitle { font-family: Arial, Helvetica, sans-serif; font-size: 16px; fill: #803c28; }
+    </style>
+  </defs>
+
+  <!-- Production draft geometry: intentionally simplified from the rendered PDF, not auto-traced. -->
+  <rect class="page" width="1440" height="810" />
+  <text x="56" y="52" class="title">Floor 2</text>
+  <text x="56" y="80" class="subtitle">Production draft. Verify room geometry and schedule names before sharing.</text>
+  <text x="56" y="128" class="note">Unavailable areas are intentionally neutralized. Not for emergency egress.</text>
+
+  <g id="floor-2-legend">
+    <rect x="1100" y="28" width="22" height="22" class="zone public" />
+    <text x="1132" y="39" class="legend-text">Public/session area</text>
+    <rect x="1100" y="54" width="22" height="22" class="zone amenity" />
+    <text x="1132" y="65" class="legend-text">Amenity/gathering</text>
+    <rect x="1100" y="80" width="22" height="22" class="zone restroom" />
+    <text x="1132" y="91" class="legend-text">Restrooms</text>
+    <rect x="1100" y="106" width="22" height="22" class="zone neutral" />
+    <text x="1132" y="117" class="legend-text">Unavailable area</text>
+  </g>
+
+  <g id="floor-2-building-outline">
+    <rect class="building" x="36" y="150" width="1384" height="644" />
+    <rect x="38" y="150" width="1030" height="180" class="neutral-hatched" opacity="0.22" />
+    <text x="555" y="222" class="note" text-anchor="middle">Large non-attendee / parking-garage area in source PDF, simplified here</text>
+  </g>
+
+  <g id="floor-2-unavailable-space">
+    <rect id="floor-2-unavailable-west-row" x="35" y="408" width="270" height="94" class="zone neutral" />
+    <rect id="floor-2-unavailable-west-lower" x="35" y="540" width="270" height="98" class="zone neutral" />
+    <rect id="floor-2-unavailable-center" x="610" y="352" width="96" height="288" class="zone neutral" />
+    <rect id="floor-2-unavailable-north-row" x="720" y="374" width="300" height="76" class="zone neutral" />
+    <rect id="floor-2-unavailable-east-inner" x="1092" y="370" width="154" height="78" class="zone neutral" />
+    <rect id="floor-2-unavailable-east-strip" x="1308" y="306" width="108" height="455" class="zone neutral" />
+    <rect id="floor-2-unavailable-south-center" x="506" y="674" width="196" height="108" class="zone neutral" />
+  </g>
+
+  <g id="floor-2-public-circulation">
+    <path class="circulation" d="M315 350 H610 V526 H706 V452 H996 V490 H1278 V780 H706 V646 H315 Z" />
+    <text x="955" y="471" class="note" text-anchor="middle">Simplified circulation. No route, ADA, or egress claims.</text>
+  </g>
+
+  <g id="floor-2-bathroom-1" class="room amenity-block" data-label="Restroom">
+    <title>Restroom</title>
+    <rect x="328" y="350" width="80" height="82" class="zone restroom" />
+    <text x="368" y="392" class="label label-restroom label-xs">Restroom</text>
+  </g>
+
+  <g id="neutral-floor-2-west-room" class="room neutral-block" aria-hidden="true">
+    <rect x="440" y="374" width="140" height="136" class="zone neutral" />
+  </g>
+
+  <g id="floor-2-hallway" class="room amenity-block" data-label="Hallway">
+    <title>Hallway</title>
+    <rect x="632" y="442" width="86" height="66" class="zone neutral" />
+    <text x="675" y="476" class="label label-dark label-small">Hallway</text>
+  </g>
+
+  <g id="floor-2-curve" class="room public-room" data-label="The CURVE">
+    <title>The CURVE</title>
+    <rect x="43" y="660" width="184" height="114" class="zone public" />
+    <text x="135" y="710" class="label">The</text>
+    <text x="135" y="733" class="label">CURVE</text>
+  </g>
+
+  <g id="neutral-floor-2-southwest-room" class="room neutral-block" aria-hidden="true">
+    <rect x="322" y="692" width="120" height="82" class="zone neutral" />
+  </g>
+
+  <g id="neutral-floor-2-north-room" class="room neutral-block" aria-hidden="true">
+    <rect x="1068" y="162" width="174" height="90" class="zone neutral" />
+  </g>
+
+  <g id="neutral-floor-2-staff-area-north" class="room neutral-block" data-label="Staff area" aria-hidden="true">
+    <rect x="1084" y="252" width="68" height="84" class="zone neutral" />
+    <rect x="1248" y="246" width="58" height="56" class="zone neutral" />
+  </g>
+
+  <g id="floor-2-bathroom-2" class="room amenity-block" data-label="Restroom">
+    <title>Restroom</title>
+    <rect x="1154" y="252" width="88" height="84" class="zone restroom" />
+    <text x="1198" y="294" class="label label-restroom label-xs">Restroom</text>
+  </g>
+
+  <g id="neutral-floor-2-east-small-room" class="room neutral-block" aria-hidden="true">
+    <rect x="1020" y="374" width="74" height="76" class="zone neutral" />
+  </g>
+
+  <g id="floor-2-extra-seating" class="room public-room" data-label="Extra Seating">
+    <title>Extra Seating</title>
+    <rect x="996" y="494" width="238" height="152" class="zone amenity" />
+    <text x="1115" y="545" class="label">Extra Seating</text>
+  </g>
+
+  <g id="floor-2-hot-desks-lounge-bar" class="room public-room" data-label="4 Hot Desks + Lounge + Bar Seating">
+    <title>4 Hot Desks + Lounge + Bar Seating</title>
+    <rect x="1010" y="560" width="210" height="66" class="zone amenity" opacity="0.92" />
+    <text x="1115" y="576" class="label label-small">4 Hot Desks + Lounge</text>
+    <text x="1115" y="598" class="label label-small">+ Bar Seating</text>
+  </g>
+
+</svg>

--- a/content/map.njk
+++ b/content/map.njk
@@ -1,0 +1,302 @@
+---
+layout: false
+permalink: /map/index.html
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>200OK Conference Map</title>
+    <meta name="description" content="Two-floor 200OK conference map for Gitwit with accessible room location summary.">
+    <link rel="icon" href="/favicon.ico" type="image/x-icon">
+    <style>
+      :root {
+        color-scheme: light;
+        --page: #ded8d1;
+        --paper: #fffaf4;
+        --ink: #4a1d0f;
+        --muted: #803c28;
+        --restroom: #da6343;
+        --border: #b99583;
+        --neutral: #f4efe8;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      body {
+        margin: 0;
+        background: var(--page);
+        color: var(--ink);
+        font-family: Arial, Helvetica, sans-serif;
+        line-height: 1.45;
+      }
+
+      a {
+        color: inherit;
+      }
+
+      .page {
+        width: min(1320px, calc(100% - 32px));
+        margin: 0 auto;
+        padding: 32px 0 44px;
+      }
+
+      .topbar {
+        margin-bottom: 24px;
+      }
+
+      .home-link {
+        display: inline-block;
+        margin-bottom: 18px;
+        color: var(--muted);
+        font-weight: 700;
+        text-decoration-thickness: 2px;
+        text-underline-offset: 4px;
+      }
+
+      h1,
+      h2,
+      h3,
+      p,
+      dl {
+        margin-top: 0;
+      }
+
+      h1 {
+        margin-bottom: 8px;
+        font-size: clamp(2.2rem, 5vw, 4.5rem);
+        line-height: 1;
+      }
+
+      .subtitle {
+        max-width: 820px;
+        margin-bottom: 0;
+        color: var(--muted);
+        font-size: 1.25rem;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(300px, 390px);
+        gap: 24px;
+        align-items: start;
+      }
+
+      .map-panel,
+      .reference-panel {
+        border: 2px solid var(--ink);
+        border-radius: 8px;
+        background: var(--paper);
+      }
+
+      .map-panel {
+        display: grid;
+        gap: 18px;
+        padding: 16px;
+      }
+
+      .floor-map {
+        margin: 0;
+      }
+
+      .floor-map img {
+        display: block;
+        width: 100%;
+        height: auto;
+        border: 1px solid var(--border);
+        background: var(--page);
+      }
+
+      .reference-panel {
+        padding: 20px;
+      }
+
+      .reference-panel h2 {
+        margin-bottom: 16px;
+        font-size: 1.35rem;
+      }
+
+      .floor-group + .floor-group {
+        margin-top: 24px;
+        padding-top: 18px;
+        border-top: 1px solid var(--border);
+      }
+
+      .floor-group h3 {
+        margin-bottom: 10px;
+        font-size: 1rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+      }
+
+      .room-list {
+        display: grid;
+        gap: 12px;
+        margin-bottom: 0;
+      }
+
+      .room-list div {
+        padding-left: 12px;
+        border-left: 4px solid var(--muted);
+      }
+
+      .room-list div[data-kind="session"] {
+        border-color: var(--ink);
+      }
+
+      .room-list div[data-kind="restroom"] {
+        border-color: var(--restroom);
+      }
+
+      .room-list dt {
+        font-weight: 800;
+      }
+
+      .room-list dd {
+        margin: 2px 0 0;
+        color: var(--muted);
+      }
+
+      .notice {
+        margin-top: 20px;
+        padding: 14px 16px;
+        border: 1px solid var(--border);
+        background: var(--neutral);
+        color: var(--muted);
+        font-size: 0.95rem;
+      }
+
+      .sr-only {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      @media (max-width: 980px) {
+        .layout {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      @media print {
+        body {
+          background: white;
+        }
+
+        .page {
+          width: auto;
+          padding: 0;
+        }
+
+        .layout {
+          display: block;
+        }
+
+        .reference-panel {
+          margin-top: 18px;
+          break-inside: avoid;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="page">
+      <header class="topbar">
+        <a class="home-link" href="/">Back to 200OK</a>
+        <h1>200OK Conference Map</h1>
+        <p class="subtitle">Production draft for review. Not for emergency egress, ADA routing, capacity, or exact measurement.</p>
+      </header>
+
+      <div class="layout">
+        <section class="map-panel" aria-labelledby="map-heading" aria-describedby="map-summary">
+          <h2 id="map-heading" class="sr-only">Visual two-floor map</h2>
+          <figure class="floor-map">
+            <img
+              src="/assets/map/200ok-floor-1.svg"
+              width="1440"
+              height="810"
+              alt="Floor 1 visual map. The room locations are listed in text next to the map.">
+          </figure>
+          <figure class="floor-map">
+            <img
+              src="/assets/map/200ok-floor-2.svg"
+              width="1440"
+              height="810"
+              alt="Floor 2 visual map. The room locations are listed in text next to the map.">
+          </figure>
+        </section>
+
+        <section class="reference-panel" aria-labelledby="summary-heading">
+          <h2 id="summary-heading">Room Locations</h2>
+          <p id="map-summary">Use this list as the text equivalent for the visual map.</p>
+
+          <section class="floor-group" aria-labelledby="floor-1-heading">
+            <h3 id="floor-1-heading">Floor 1</h3>
+            <dl class="room-list">
+              <div data-kind="restroom">
+                <dt>Restrooms</dt>
+                <dd>North attendee area, with two additional restroom blocks near the northeast side.</dd>
+              </div>
+              <div>
+                <dt>The Kitchen</dt>
+                <dd>North-center, directly beside the main restroom block.</dd>
+              </div>
+              <div>
+                <dt>Check-in / Front Desk</dt>
+                <dd>Southwest-middle area, near attendee circulation.</dd>
+              </div>
+              <div>
+                <dt>The CAFE</dt>
+                <dd>South side of Floor 1.</dd>
+              </div>
+              <div data-kind="session">
+                <dt>The FORUM</dt>
+                <dd>South-center session room.</dd>
+              </div>
+              <div data-kind="session">
+                <dt>The CUBE</dt>
+                <dd>Southeast side. Speaker's Green Room except during scheduled breakout sessions.</dd>
+              </div>
+              <div>
+                <dt>Mother's Room</dt>
+                <dd>East side of Floor 1.</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section class="floor-group" aria-labelledby="floor-2-heading">
+            <h3 id="floor-2-heading">Floor 2</h3>
+            <dl class="room-list">
+              <div data-kind="restroom">
+                <dt>Restrooms</dt>
+                <dd>One near west-center and one near the northeast side.</dd>
+              </div>
+              <div data-kind="session">
+                <dt>The CURVE</dt>
+                <dd>Southwest side session room.</dd>
+              </div>
+              <div>
+                <dt>Extra Seating</dt>
+                <dd>Southeast side, including hot desks, lounge, and bar seating.</dd>
+              </div>
+              <div>
+                <dt>Hallway</dt>
+                <dd>Near the center of Floor 2.</dd>
+              </div>
+            </dl>
+          </section>
+
+          <p class="notice">Unavailable areas are intentionally unlabeled. Verify final room names against the published schedule before sharing.</p>
+        </section>
+      </div>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- Add a standalone /map page for the 200OK conference venue map
- Add the finalized floor 1 and floor 2 SVG assets
- Include accessible image descriptions plus an HTML room summary for screen readers and quick scanning

## Verification
- npm run build
- HTML/ARIA reference and SVG title/desc structural checks
- git diff --check -- content/map.njk assets/map/200ok-floor-1.svg assets/map/200ok-floor-2.svg

## Deploy note
Direct Netlify production deploy was blocked because this authenticated Netlify account cannot access the 200ok site. Production deploy should proceed through the protected main branch after PR merge/merge queue.